### PR TITLE
Add short notice regarding install prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,18 @@ clR package performs three kinds of analysis:
 * Stucture - builds force-directed graphs based on co-authorships of articles.
 
 * Content - builds Latent Dirichlet Allocation model on article abstract text. 
+
+## Prerequisites
+
+The development packages of the following libraries need to be installed in order to compile clR's dependencies:
+
+- libcurl
+- openssl
+- libssh2
+- udunits2
+- libxml2
+- gsl
+
+On CentOS, this requirement may be satisfied by executing the following command:
+
+```# yum -y install libcurl-devel openssl-devel libssh2-devel udunits2-devel libxml2-devel gsl-devel```


### PR DESCRIPTION
Makes it much easier to set up a machine with the correct dependencies without having to investigate the install logs/package documentations